### PR TITLE
SPI Flash控制器

### DIFF
--- a/src/devctrl.vhd
+++ b/src/devctrl.vhd
@@ -28,7 +28,6 @@ entity devctrl is
 
         -- Signals connecting to flash_ctrl --
         flashEnable_o: out std_logic;
-        flashReadEnable_o: out std_logic;
         flashDataLoad_i: in std_logic_vector(DataWidth);
         flashBusy_i: in std_logic;
 
@@ -86,7 +85,6 @@ begin
         ram1ReadEnable_o <= ENABLE;
         ram1DataSave_o <= (others => '0');
         flashEnable_o <= DISABLE;
-        flashReadEnable_o <= ENABLE;
         comEnable_o <= DISABLE;
         comReadEnable_o <= ENABLE;
         comDataSave_o <= (others => '0');
@@ -125,7 +123,6 @@ begin
             elsif (devPhysicalAddr_i >= 32ux"1e000000" and devPhysicalAddr_i <= 32ux"1effffff") then
                 -- flash --
                 flashEnable_o <= ENABLE;
-                flashReadEnable_o <= not devWrite_i;
                 devDataLoad_o <= flashDataLoad_i;
                 devBusy_o <= flashBusy_i;
             elsif (devPhysicalAddr_i >= 32ux"1fc00000" and devPhysicalAddr_i <= 32ux"1fc00fff") then

--- a/src/flash_ctrl.vhd
+++ b/src/flash_ctrl.vhd
@@ -3,49 +3,45 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_unsigned.all;
 use ieee.std_logic_arith.all;
 use work.global_const.all;
-use work.flash_const.all;
 
 entity flash_ctrl is
     port (
         clk, rst: in std_logic;
         devEnable_i: in std_logic;
         addr_i: in std_logic_vector(AddrWidth);
-        readEnable_i: in std_logic;
         readData_o: out std_logic_vector(DataWidth);
         busy_o: out std_logic;
 
-        flRst_o, flOE_o, flCE_o, flWE_o: out std_logic;
-        flAddr_o: out std_logic_vector(FlashAddrWidth);
-        flData_i: in std_logic_vector(FlashDataWidth);
-        flByte_o, flVpen_o: out std_logic
+        clk_o, cs_n_o, di_o: out std_logic;
+        do_i: in std_logic
     );
 end flash_ctrl;
 
 architecture bhv of flash_ctrl is
-    signal state: std_logic_vector(2 downto 0);
+    constant CMD_READ: std_logic_vector(7 downto 0) := x"03";
+    signal state: std_logic_vector(5 downto 0);
+    signal cmdAndAddr: std_logic_vector(0 to 31); -- Output from high to low
+    signal data: std_logic_vector(0 to 31); -- Input from high to low
 begin
 
-    flRst_o <= not rst;
-    flCE_o <= not devEnable_i;
-    flOE_o <= not (devEnable_i and readEnable_i);
-    flWE_o <= '1';
-    flByte_o <= '1';
-    flVpen_o <= '1';
-    busy_o <= '0' when state = CLKS_TO_GET_DATA else '1';
-    readData_o <= 16ux"0" & flData_i;
-    flAddr_o <= addr_i(FlashAddrSliceWidth) & '0';
+    clk_o <= clk;
+    cs_n_o <= not devEnable_i;
+    busy_o <= '0' when state = "111111" else '1';
+    readData_o <= data;
+    cmdAndAddr <= CMD_READ & addr_i(23 downto 0);
 
-    process(clk)
-    begin
+    process (clk) begin
         if (rising_edge(clk)) then
             if (rst = RST_ENABLE or devEnable_i = DISABLE) then
                 state <= (others => '0');
+                data <= (others => '0');
             else
-                if (conv_integer(state) = CLKS_TO_GET_DATA) then
-                    state <= (others => '0');
+                if (state(5) = '0') then
+                    di_o <= cmdAndAddr(conv_integer(state));
                 else
-                    state <= state + 1;
+                    data(conv_integer(state)) <= do_i;
                 end if;
+                state <= state + 1;
             end if;
         end if;
     end process;

--- a/src/flash_ctrl.vhd
+++ b/src/flash_ctrl.vhd
@@ -52,7 +52,7 @@ begin
             rxd <= rxd(30 downto 0) & do_i;
         end if;
     end process;
-    readData_o <= rxd;
+    readData_o <= rxd(7 downto 0) & rxd(15 downto 8) & rxd(23 downto 16) & rxd(31 downto 24);
 
     process (clk) begin -- Controller
         if (rising_edge(clk)) then

--- a/src/packages/flash_const.vhd
+++ b/src/packages/flash_const.vhd
@@ -1,9 +1,0 @@
-package flash_const is
-    constant CLKS_TO_GET_DATA: integer := 3;
-
-    subtype FlashAddrSliceWidth is integer range 23 downto 2;
-    subtype FlashAddrWidth is integer range 22 downto 0;
-    subtype FlashDataWidth is integer range 15 downto 0;
-    subtype FlashDataHiWidth is integer range 31 downto 16;
-    subtype FlashDataLoWidth is integer range 15 downto 0;
-end flash_const;

--- a/src/top.v
+++ b/src/top.v
@@ -24,7 +24,7 @@ output wire[1:0] led_rg0, led_rg1; // Dual color LED
 output wire[7:0] num_cs_n; // 7-seg enable
 output wire[6:0] num_a_g; // 7-seg data
 
-input wire[7:0] switch; // Switches
+input wire[7:0] switch; // Switches. Push up for 0 and pull down for 1
 input wire[3:0] btn_key_col, btn_key_row; // Keypad
 input wire[1:0] btn_step; // Pulse button
 

--- a/src/top.v
+++ b/src/top.v
@@ -117,7 +117,7 @@ wire[31:0] ram0DataSave, ram0DataLoad;
 wire ram1Enable, ram1ReadEnable, ram1WriteBusy;
 wire[31:0] ram1DataSave, ram1DataLoad;
 
-wire flashEnable, flashReadEnable, flashBusy;
+wire flashEnable, flashBusy;
 wire[31:0] flashDataLoad;
 
 wire vgaEnable, vgaWriteEnable;
@@ -162,7 +162,6 @@ devctrl devctrl_ist(
     .ram1WriteBusy_i(ram1WriteBusy),
 
     .flashEnable_o(flashEnable),
-    .flashReadEnable_o(flashReadEnable),
     .flashDataLoad_i(flashDataLoad),
     .flashBusy_i(flashBusy),
 
@@ -242,25 +241,18 @@ assign ext_ram_data = ram1TriStateWrite ? ram1DataSave : 32'hzzzzzzzz;
 assign ram1DataLoad = ext_ram_data;
 */
 
-/*
 flash_ctrl flash_ctrl_ist(
     .clk(clkMain),
     .rst(rst),
     .devEnable_i(flashEnable),
     .addr_i(addr),
-    .readEnable_i(flashReadEnable),
     .readData_o(flashDataLoad),
     .busy_o(flashBusy),
-    .flRst_o(flash_rp_n),
-    .flOE_o(flash_oe_n),
-    .flCE_o(flash_ce_n),
-    .flWE_o(flash_we_n),
-    .flAddr_o(flash_a),
-    .flData_i(flash_data),
-    .flByte_o(flash_byte_n),
-    .flVpen_o(flash_vpen)
+    .clk_o(spi_clk),
+    .cs_n_o(spi_cs_n),
+    .di_o(spi_di),
+    .do_i(spi_do)
 );
-*/
 
 /*
 vga_ctrl vga_ctrl_ist(

--- a/thinpad_top/thinpad_top.xpr
+++ b/thinpad_top/thinpad_top.xpr
@@ -220,6 +220,12 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
+      <File Path="$PPRDIR/../src/flash_ctrl.vhd">
+        <FileInfo SFType="VHDL2008">
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
       <File Path="$PPRDIR/../src/lattice_ram_ctrl.vhd">
         <FileInfo SFType="VHDL2008">
           <Attr Name="UsedIn" Val="synthesis"/>
@@ -246,20 +252,6 @@
         </FileInfo>
       </File>
       <File Path="$PPRDIR/../src/eth_ctrl.vhd">
-        <FileInfo SFType="VHDL2008">
-          <Attr Name="AutoDisabled" Val="1"/>
-          <Attr Name="UsedIn" Val="synthesis"/>
-          <Attr Name="UsedIn" Val="simulation"/>
-        </FileInfo>
-      </File>
-      <File Path="$PPRDIR/../src/packages/flash_const.vhd">
-        <FileInfo SFType="VHDL2008">
-          <Attr Name="AutoDisabled" Val="1"/>
-          <Attr Name="UsedIn" Val="synthesis"/>
-          <Attr Name="UsedIn" Val="simulation"/>
-        </FileInfo>
-      </File>
-      <File Path="$PPRDIR/../src/flash_ctrl.vhd">
         <FileInfo SFType="VHDL2008">
           <Attr Name="AutoDisabled" Val="1"/>
           <Attr Name="UsedIn" Val="synthesis"/>
@@ -1658,16 +1650,14 @@
     </Run>
     <Run Id="clk_ctrl_synth_1" Type="Ft3:Synth" SrcSet="clk_ctrl" Part="xc7a200tfbg676-2" ConstrsSet="clk_ctrl" Description="Vivado Synthesis Defaults" Dir="$PRUNDIR/clk_ctrl_synth_1" IncludeInArchive="true">
       <Strategy Version="1" Minor="2">
-        <StratHandle Name="Vivado Synthesis Defaults" Flow="Vivado Synthesis 2017">
-          <Desc>Vivado Synthesis Defaults</Desc>
-        </StratHandle>
+        <StratHandle Name="Vivado Synthesis Defaults" Flow="Vivado Synthesis 2017"/>
         <Step Id="synth_design"/>
       </Strategy>
       <GeneratedRun Dir="$PRUNDIR" File="gen_run.xml"/>
       <ReportStrategy/>
       <Report Name="ROUTE_DESIGN.REPORT_METHODOLOGY" Enabled="1"/>
     </Run>
-    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a200tfbg676-2" ConstrsSet="constrs_1" Description="Default settings for Implementation." State="current" SynthRun="synth_1" IncludeInArchive="true">
+    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a200tfbg676-2" ConstrsSet="constrs_1" Description="Default settings for Implementation." State="current" Dir="$PRUNDIR/impl_1" SynthRun="synth_1" IncludeInArchive="true">
       <Strategy Version="1" Minor="2">
         <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2016"/>
         <Step Id="init_design"/>
@@ -1680,6 +1670,7 @@
         <Step Id="post_route_phys_opt_design"/>
         <Step Id="write_bitstream"/>
       </Strategy>
+      <GeneratedRun Dir="$PRUNDIR" File="gen_run.xml"/>
       <ReportStrategy/>
       <Report Name="ROUTE_DESIGN.REPORT_METHODOLOGY" Enabled="1"/>
     </Run>
@@ -1717,9 +1708,7 @@
     </Run>
     <Run Id="clk_ctrl_impl_1" Type="Ft2:EntireDesign" Part="xc7a200tfbg676-2" ConstrsSet="clk_ctrl" Description="Default settings for Implementation." SynthRun="clk_ctrl_synth_1" IncludeInArchive="false">
       <Strategy Version="1" Minor="2">
-        <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2017">
-          <Desc>Default settings for Implementation.</Desc>
-        </StratHandle>
+        <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2017"/>
         <Step Id="init_design"/>
         <Step Id="opt_design"/>
         <Step Id="power_opt_design"/>


### PR DESCRIPTION
实现了SPI Flash控制器。向Flash写入若干指令（写入方法见wiki），SoC可以正确执行这些指令并向串口和LED输出。

Flash控制器工作原理如下：读取一个32位字需要66个周期。第0个周期接受请求，并存储在寄存器，不做其他操作（因为下一个周期的下降沿就要使用）。第1\~8个周期中间的下降沿处向`di_o`（MOSI，Master Out Slave In）逐位（大端序，下同）写入读指令`0x03`，芯片在周期结束的上升沿处采样。第9\~32个周期中间的下降沿处向`di_o`逐位写入24位地址，芯片在周期结束的上升沿处采样。第33\~64周期中间的下降沿处芯片向`do_i`（MISO，Master In Slave Out）逐位写入数据，SoC在周期结束的上升沿处采样。第65个周期向CPU返回结果。

@XemboLiu 请注意，现在FPGA是按字节编址，请对Bootloader做相应修改。

由于向龙芯开发板的Flash写入时，字节序行为与thinpad相反，所以Flash控制器中转换了一次字节序。

如果要修改Flash控制器，请务必注意工程中的`di`指的是MOSI，引脚绑定文档的DI指的是MISO，芯片文档中的DI指的是MOSI，电路图中两种含义都有（见上下文）。
