### PR TITLE
完成ddr3控制器成组读取，并实现了一个直接映射cache

### DIFF
--- a/src/datapath.vhd
+++ b/src/datapath.vhd
@@ -347,7 +347,8 @@ begin
             exceptCause_i => exceptCause_24,
             exceptCause_o => exceptCause_45,
             currentInstAddr_o => currentInstAddr_45,
-            isIdEhb_o => isIdEhb_4b
+            isIdEhb_o => isIdEhb_4b,
+            nextWillStall_i => stall(ID_STOP_IDX)
         );
 
     id_ex_ist: entity work.id_ex

--- a/src/ddr3_ctrl_100.vhd
+++ b/src/ddr3_ctrl_100.vhd
@@ -11,7 +11,7 @@ entity ddr3_ctrl_100 is
         enable_i, readEnable_i: in std_logic; -- read enable means write disable
         addr_i: in std_logic_vector(31 downto 0);
         writeData_i: in std_logic_vector(31 downto 0);
-        readData_o: out std_logic_vector(31 downto 0);
+        readDataBurst_o: out BurstDataType;
         byteSelect_i: in std_logic_vector(3 downto 0);
         busy_o: out std_logic;
 
@@ -55,7 +55,6 @@ architecture bhv of ddr3_ctrl_100 is
 
     signal wid, rid: std_logic_vector(7 downto 0);
     signal recv_cnt: std_logic_vector(BurstLenWidth);
-    signal readData: BurstDataType;
     signal readData_reg: BurstDataType;
     signal readData_last: std_logic_vector(31 downto 0);
     signal round_zeros: std_logic_vector((BURST_LEN_WIDTH + 1) downto 0);
@@ -101,9 +100,8 @@ begin
 
     busy_o <= (not (axi_rlast_i and axi_rvalid_i)) when readEnable_i = ENABLE else (not axi_bvalid_i);
     readData_last <= axi_rdata_i;
-    readData(0 to BURST_LEN - 2) <= readData_reg(0 to BURST_LEN - 2);
-    readData(BURST_LEN - 1) <= readData_last;
-    readData_o <= readData(conv_integer(addr_i(BURST_LEN_WIDTH + 1 downto 2)));
+    readDataBurst_o(0 to BURST_LEN - 2) <= readData_reg(0 to BURST_LEN - 2);
+    readDataBurst_o(BURST_LEN - 1) <= readData_last;
 
     process(clk) begin
         if (rising_edge(clk)) then

--- a/src/ddr3_ctrl_100.vhd
+++ b/src/ddr3_ctrl_100.vhd
@@ -1,5 +1,8 @@
 library ieee;
 use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+use work.ddr3_const.all;
 
 entity ddr3_ctrl_100 is
     port (
@@ -51,6 +54,11 @@ end ddr3_ctrl_100;
 architecture bhv of ddr3_ctrl_100 is
 
     signal wid, rid: std_logic_vector(7 downto 0);
+    signal recv_cnt: std_logic_vector(BurstLenWidth);
+    signal readData: BurstDataType;
+    signal readData_reg: BurstDataType;
+    signal readData_last: std_logic_vector(31 downto 0);
+    signal round_zeros: std_logic_vector((BURST_LEN_WIDTH + 1) downto 0);
     
     type ReadState is (INIT, READ);
     signal rstate: ReadState;
@@ -65,7 +73,7 @@ begin
     axi_awid_o <= wid;
     axi_awaddr_o <= addr_i(26 downto 0);
     axi_awlen_o <= 8ub"0";
-    axi_awsize_o <= "101";
+    axi_awsize_o <= "010";
     axi_awburst_o <= "01";
     axi_awvalid_o <= '1' when (wstate = INIT or wstate = DOK) and enable_i = ENABLE and readEnable_i = DISABLE else '0';
 
@@ -81,30 +89,41 @@ begin
     rid <= 8ub"0";
 
     axi_arid_o <= rid;
-    axi_araddr_o <= addr_i(26 downto 0);
-    axi_arlen_o <= 8ub"0";
-    axi_arsize_o <= "101";
+    round_zeros <= (others => '0');
+    axi_araddr_o <= addr_i(26 downto (BURST_LEN_WIDTH + 2)) & round_zeros;
+    axi_arlen_o <= conv_std_logic_vector(BURST_LEN - 1, 8);
+    axi_arsize_o <= "010";
     axi_arburst_o <= "01";
     --
     axi_arvalid_o <= '1' when rstate = INIT and enable_i = ENABLE and readEnable_i = ENABLE else '0';
 
-    readData_o <= axi_rdata_i;
     axi_rready_o <= '1' when rstate = READ else '0';
 
     busy_o <= (not (axi_rlast_i and axi_rvalid_i)) when readEnable_i = ENABLE else (not axi_bvalid_i);
+    readData_last <= axi_rdata_i;
+    readData(0 to BURST_LEN - 2) <= readData_reg(0 to BURST_LEN - 2);
+    readData(BURST_LEN - 1) <= readData_last;
+    readData_o <= readData(conv_integer(addr_i(BURST_LEN_WIDTH + 1 downto 2)));
 
     process(clk) begin
         if (rising_edge(clk)) then
             if (rst = '1') then
                 rstate <= INIT;
                 wstate <= INIT;
+                recv_cnt <= (others => '0');
             else
 
                 if (enable_i = ENABLE and readEnable_i = ENABLE) then
                     if (rstate = INIT and axi_arready_i = '1') then
                         rstate <= READ;
                     elsif (rstate = READ and axi_rvalid_i = '1') then
-                        rstate <= INIT;
+                        if (recv_cnt = BURST_LEN - 1) then
+                            rstate <= INIT;
+                            recv_cnt <= (others => '0');
+                        else
+                            readData_reg(conv_integer(recv_cnt)) <= axi_rdata_i;
+                            recv_cnt <= recv_cnt + 1;
+                        end if;
                     end if;
                 end if;
 

--- a/src/ddr3_ctrl_cache.vhd
+++ b/src/ddr3_ctrl_cache.vhd
@@ -1,0 +1,70 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+use work.global_const.all;
+use work.ddr3_const.all;
+
+entity ddr3_ctrl_cache is
+    port (
+        clk, rst: in std_logic;
+        enable_i, readEnable_i: in std_logic;
+        addr_i: in std_logic_vector(AddrWidth);
+        writeData_i: in std_logic_vector(DataWidth);
+        readData_o: out std_logic_vector(DataWidth);
+        byteSelect_i: in std_logic_vector(3 downto 0);
+        busy_o: out std_logic;
+
+        enable_o: out std_logic;
+        readDataBurst_i: in BurstDataType;
+        busy_i: in std_logic
+    );
+end ddr3_ctrl_cache;
+
+architecture bhv of ddr3_ctrl_cache is
+    signal table: CacheTableType;
+    signal tag: std_logic_vector(TAG_WIDTH - 1 downto 0);
+    signal index, offset: integer;
+    signal needToRead: std_logic;
+begin
+    
+    tag <= addr_i(26 downto 27 - TAG_WIDTH);
+    index <= conv_integer(addr_i(26 - TAG_WIDTH downto 27 - TAG_WIDTH - INDEX_WIDTH));
+    offset <= conv_integer(addr_i(OFFSET_WIDTH + 1 downto 2));
+
+    needToRead <= '0' when (table(index).tag = tag and table(index).present = '1') else '1';
+    busy_o <= needToRead when readEnable_i = ENABLE else busy_i;
+    readData_o <= table(index).data(offset) when (enable_i = ENABLE and readEnable_i = ENABLE and needToRead = '0') else (others => '0');
+
+    enable_o <= ENABLE when (enable_i = ENABLE and (readEnable_i = DISABLE or needToRead = '1')) else DISABLE;
+
+    process (clk) begin
+        if (rising_edge(clk)) then
+            if (rst = RST_ENABLE) then
+                table <= (others => (present => '0', tag => (others => '0'), data => (others => (others => '0'))));
+            else
+                if (enable_i = ENABLE) then
+                    if (readEnable_i = ENABLE and busy_i = PIPELINE_NONSTOP) then
+                        table(index) <= (present => '1', tag => tag, data => readDataBurst_i);
+                    elsif (readEnable_i = DISABLE) then
+                        if (table(index).present = '1' and table(index).tag = tag) then
+                            if (byteSelect_i(0) = '1') then
+                                table(index).data(offset)(7 downto 0) <= writeData_i(7 downto 0);
+                            end if;
+                            if (byteSelect_i(1) = '1') then
+                                table(index).data(offset)(15 downto 8) <= writeData_i(15 downto 8);
+                            end if;
+                            if (byteSelect_i(2) = '1') then
+                                table(index).data(offset)(23 downto 16) <= writeData_i(23 downto 16);
+                            end if;
+                            if (byteSelect_i(3) = '1') then
+                                table(index).data(offset)(31 downto 24) <= writeData_i(31 downto 24);
+                            end if;
+                        end if;
+                    end if;
+                end if;
+            end if;
+        end if;
+    end process;
+
+end bhv;

--- a/src/ddr3_ctrl_encap.vhd
+++ b/src/ddr3_ctrl_encap.vhd
@@ -96,6 +96,10 @@ architecture bhv of ddr3_ctrl_encap is
 
     signal ui_clk, ui_clk_sync_rst, rst_n, aresetn: std_logic;
 
+    signal enable_25_i: std_logic;
+    signal readDataBurst_25_o: BurstDataType;
+    signal busy_25_o: std_logic;
+
     signal enable_100_i, readEnable_100_i: std_logic;
     signal addr_100_i: std_logic_vector(31 downto 0);
     signal writeData_100_i: std_logic_vector(31 downto 0);
@@ -103,11 +107,7 @@ architecture bhv of ddr3_ctrl_encap is
     signal byteSelect_100_i: std_logic_vector(3 downto 0);
     signal busy_100_o: std_logic;
 
-    signal readDataBurst: BurstDataType;
-
 begin
-
-    readData_o <= readDataBurst(conv_integer(addr_i(BURST_LEN_WIDTH + 1 downto 2)));
 
     axi_awlock <= "0";
     axi_awcache <= "0000";
@@ -196,6 +196,21 @@ begin
             -- app_zq_ack =>
         );
 
+    ddr3_ctrl_cache_ist: entity work.ddr3_ctrl_cache
+        port map (
+            clk => clk_25, rst => rst,
+            enable_i => enable_i,
+            readEnable_i => readEnable_i,
+            addr_i => addr_i,
+            writeData_i => writeData_i,
+            readData_o => readData_o,
+            byteSelect_i => byteSelect_i,
+            busy_o => busy_o,
+            enable_o => enable_25_i,
+            readDataBurst_i => readDataBurst_25_o,
+            busy_i => busy_25_o
+        );
+
     ddr3_ctrl_ist: entity work.ddr3_ctrl
         port map (
             clk_100 => ui_clk,
@@ -203,13 +218,13 @@ begin
             rst_100 => ui_clk_sync_rst,
             rst_25 => rst,
 
-            enable_i => enable_i,
+            enable_i => enable_25_i,
             readEnable_i => readEnable_i,
             addr_i => addr_i,
             writeData_i => writeData_i,
-            readDataBurst_o => readDataBurst,
+            readDataBurst_o => readDataBurst_25_o,
             byteSelect_i => byteSelect_i,
-            busy_o => busy_o,
+            busy_o => busy_25_o,
 
             enable_o => enable_100_i,
             readEnable_o => readEnable_100_i,

--- a/src/ddr3_ctrl_encap.vhd
+++ b/src/ddr3_ctrl_encap.vhd
@@ -1,7 +1,9 @@
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
 use work.global_const.all;
+use work.ddr3_const.all;
 
 entity ddr3_ctrl_encap is
     port (
@@ -97,11 +99,15 @@ architecture bhv of ddr3_ctrl_encap is
     signal enable_100_i, readEnable_100_i: std_logic;
     signal addr_100_i: std_logic_vector(31 downto 0);
     signal writeData_100_i: std_logic_vector(31 downto 0);
-    signal readData_100_o: std_logic_vector(31 downto 0);
+    signal readDataBurst_100_o: BurstDataType;
     signal byteSelect_100_i: std_logic_vector(3 downto 0);
     signal busy_100_o: std_logic;
 
+    signal readDataBurst: BurstDataType;
+
 begin
+
+    readData_o <= readDataBurst(conv_integer(addr_i(BURST_LEN_WIDTH + 1 downto 2)));
 
     axi_awlock <= "0";
     axi_awcache <= "0000";
@@ -201,7 +207,7 @@ begin
             readEnable_i => readEnable_i,
             addr_i => addr_i,
             writeData_i => writeData_i,
-            readData_o => readData_o,
+            readDataBurst_o => readDataBurst,
             byteSelect_i => byteSelect_i,
             busy_o => busy_o,
 
@@ -209,7 +215,7 @@ begin
             readEnable_o => readEnable_100_i,
             addr_o => addr_100_i,
             writeData_o => writeData_100_i,
-            readData_i => readData_100_o,
+            readDataBurst_i => readDataBurst_100_o,
             byteSelect_o => byteSelect_100_i,
             busy_i => busy_100_o
         );
@@ -223,7 +229,7 @@ begin
             readEnable_i => readEnable_100_i,
             addr_i => addr_100_i,
             writeData_i => writeData_100_i,
-            readData_o => readData_100_o,
+            readDataBurst_o => readDataBurst_100_o,
             byteSelect_i => byteSelect_100_i,
             busy_o => busy_100_o,
 

--- a/src/id.vhd
+++ b/src/id.vhd
@@ -53,7 +53,9 @@ entity id is
         valid_o: out std_logic;
         exceptCause_i: in std_logic_vector(ExceptionCauseWidth);
         exceptCause_o: out std_logic_vector(ExceptionCauseWidth);
-        currentInstAddr_o: out std_logic_vector(AddrWidth)
+        currentInstAddr_o: out std_logic_vector(AddrWidth);
+
+        nextWillStall_i: in std_logic
     );
 end id;
 
@@ -143,6 +145,7 @@ architecture bhv of id is
     signal immInstrAddr: std_logic_vector(AddrWidth);
     signal instImmSign: std_logic_vector(InstOffsetImmWidth);
     signal instOffsetImm: std_logic_vector(InstOffsetImmWidth);
+
 begin
 
     -- Segment the instruction --
@@ -1088,12 +1091,12 @@ begin
             exceptCause_o <= ADDR_ERR_LOAD_OR_IF_CAUSE;
         end if;
 
-        if (toStall = PIPELINE_STOP) then
-            branchFlag := NOT_BRANCH_FLAG; -- See pc_reg.vhd for reason
-        end if;
-
         if (tneFlag = YES and operand1 /= operand2) then
             exceptCause_o <= TRAP_CAUSE;
+        end if;
+
+        if (nextWillStall_i = '1') then
+            branchFlag := NOT_BRANCH_FLAG;
         end if;
 
         operand1_o <= operand1;

--- a/src/packages/ddr3_const.vhd
+++ b/src/packages/ddr3_const.vhd
@@ -9,4 +9,19 @@ package ddr3_const is
     subtype BurstLenWidth is integer range BURST_LEN_WIDTH - 1 downto 0;
     type BurstDataType is array(0 to (BURST_LEN - 1)) of std_logic_vector(31 downto 0);
 
+
+    constant OFFSET_WIDTH: integer := BURST_LEN_WIDTH;
+    constant INDEX_WIDTH: integer := 4;
+    constant TAG_WIDTH: integer := 25 - OFFSET_WIDTH - INDEX_WIDTH;
+
+    constant INDEX_NUM: integer := 16;
+
+    type CacheItemType is record
+        present: std_logic;
+        tag: std_logic_vector(TAG_WIDTH - 1 downto 0);
+        data: BurstDataType;
+    end record CacheItemType;
+
+    type CacheTableType is array(0 to INDEX_NUM - 1) of CacheItemType;
+
 end ddr3_const;

--- a/src/packages/ddr3_const.vhd
+++ b/src/packages/ddr3_const.vhd
@@ -1,0 +1,12 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+package ddr3_const is
+
+    constant BURST_LEN: integer := 8;
+    constant BURST_LEN_WIDTH: integer := 3;
+
+    subtype BurstLenWidth is integer range BURST_LEN_WIDTH - 1 downto 0;
+    type BurstDataType is array(0 to (BURST_LEN - 1)) of std_logic_vector(31 downto 0);
+
+end ddr3_const;

--- a/thinpad_top/thinpad_top.srcs/sources_1/ip/mig_ddr3/tcl.log
+++ b/thinpad_top/thinpad_top.srcs/sources_1/ip/mig_ddr3/tcl.log
@@ -580,3 +580,7 @@ MIG: 18:15:08 : IGN:         <InputClkFreq>100</InputClkFreq> <==>         <Inpu
 MIG: 18:15:08 : Running implementation.xit
 MIG: 18:15:08 : IGN:     <ModuleName>mig_ddr3</ModuleName> <==>     <ModuleName>mig_ddr3</ModuleName> 
 MIG: 18:15:08 : IGN:         <InputClkFreq>100</InputClkFreq> <==>         <InputClkFreq>100</InputClkFreq> 
+MIG: 00:37:12 : xml_input_file: mig_b.prj
+MIG: 00:37:12 : Absolute path of xml_input_file: e:/Development/OS2018spring-projects-g05/thinpad_top/thinpad_top.srcs/sources_1/ip/mig_ddr3/mig_b.prj
+MIG: 00:37:12 : xml_input_file: mig_b.prj
+MIG: 00:37:12 : Absolute path of xml_input_file: e:/Development/OS2018spring-projects-g05/thinpad_top/thinpad_top.srcs/sources_1/ip/mig_ddr3/mig_b.prj

--- a/thinpad_top/thinpad_top.xpr
+++ b/thinpad_top/thinpad_top.xpr
@@ -58,6 +58,12 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
+      <File Path="$PPRDIR/../src/packages/ddr3_const.vhd">
+        <FileInfo>
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
       <File Path="$PPRDIR/../src/packages/global_const.vhd">
         <FileInfo SFType="VHDL2008">
           <Attr Name="UsedIn" Val="synthesis"/>
@@ -1690,10 +1696,10 @@
         <StratHandle Name="Flow_PerfOptimized_high" Flow="Vivado Synthesis 2017"/>
         <Step Id="synth_design">
           <Option Id="ResourceSharing">2</Option>
-          <Option Id="NoCombineLuts">1</Option>
-          <Option Id="MoreOptsStr"><![CDATA[-verilog_define USE_BOOTLOADER -verilog_define FUNC_TEST]]></Option>
           <Option Id="RepFanoutThreshold">400</Option>
           <Option Id="ShregMinSize">5</Option>
+          <Option Id="NoCombineLuts">1</Option>
+          <Option Id="MoreOptsStr"><![CDATA[-verilog_define USE_BOOTLOADER -verilog_define FUNC_TEST]]></Option>
           <Option Id="FsmExtraction">1</Option>
           <Option Id="KeepEquivalentRegisters">1</Option>
         </Step>

--- a/thinpad_top/thinpad_top.xpr
+++ b/thinpad_top/thinpad_top.xpr
@@ -70,6 +70,12 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
+      <File Path="$PPRDIR/../src/ddr3_ctrl_cache.vhd">
+        <FileInfo>
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
       <File Path="$PPRDIR/../src/ddr3_ctrl.vhd">
         <FileInfo SFType="VHDL2008">
           <Attr Name="UsedIn" Val="synthesis"/>
@@ -1696,11 +1702,11 @@
         <StratHandle Name="Flow_PerfOptimized_high" Flow="Vivado Synthesis 2017"/>
         <Step Id="synth_design">
           <Option Id="ResourceSharing">2</Option>
-          <Option Id="RepFanoutThreshold">400</Option>
-          <Option Id="ShregMinSize">5</Option>
-          <Option Id="NoCombineLuts">1</Option>
-          <Option Id="MoreOptsStr"><![CDATA[-verilog_define USE_BOOTLOADER -verilog_define FUNC_TEST]]></Option>
           <Option Id="FsmExtraction">1</Option>
+          <Option Id="ShregMinSize">5</Option>
+          <Option Id="MoreOptsStr"><![CDATA[-verilog_define USE_BOOTLOADER -verilog_define FUNC_TEST]]></Option>
+          <Option Id="NoCombineLuts">1</Option>
+          <Option Id="RepFanoutThreshold">400</Option>
           <Option Id="KeepEquivalentRegisters">1</Option>
         </Step>
       </Strategy>


### PR DESCRIPTION
cache参数在`packages/ddr3_const.vhd`里调，其中每个block的大小就是`BURST_LEN*32`，`BURST_LEN`就是成组读的组数（每组32位）。

另一方面修复了之前的bug：之前只考虑了id阶段请求暂停时需要ignore掉计算出的`branchFlag`却未考虑ex和mem阶段请求暂停时也是同样的道理。

能跑功能测例，未跑u-boot。