### PR TITLE
改进串口控制器

### DIFF
--- a/src/serial_ctrl.vhd
+++ b/src/serial_ctrl.vhd
@@ -24,16 +24,23 @@ end serial_ctrl;
 architecture bhv of serial_ctrl is
     signal recvAvail: std_logic;
     signal recvData: std_logic_vector(7 downto 0);
+    signal txIRE, rxIRE: std_logic; -- Interrupt Enable
+    constant TX_READY: integer := 0;
+    constant RX_READY: integer := 1;
+    constant TX_IRE: integer := 2;
+    constant RX_IRE: integer := 3;
 begin
-    dataLoad_o <=
-            (1 => rxdReady_i or recvAvail, 0 => not txdBusy_i, others => '0')
-        when mode_i = '1' else
+    dataLoad_o <= (
+            TX_READY => not txdBusy_i,
+            RX_READY => rxdReady_i or recvAvail,
+            TX_IRE => txIRE,
+            RX_IRE => rxIRE,
+            others => '0'
+        ) when mode_i = '1' else
             24ux"0" & rxdData_i when rxdReady_i = '1' else 24ux"0" & recvData;
     -- When recvAvail = NO or chip disabled, outputting whatever is OK
 
-    int_o <= recvAvail;
-    -- Do NOT use rxdReady_i. If data comes when we are handling an exception,
-    -- we must get acknowledged after returing to user mode.
+    int_o <= ((rxdReady_i or recvAvail) and rxIRE) or (not txdBusy_i and txIRE);
 
     process (clk) begin
         if (rising_edge(clk)) then
@@ -42,19 +49,27 @@ begin
             if (rst = RST_ENABLE) then
                 recvAvail <= NO;
                 recvData <= (others => '0');
+                txIRE <= NO;
+                rxIRE <= YES;
             else
                 if (rxdReady_i = '1') then
                     recvAvail <= YES;
                     recvData <= rxdData_i;
-                elsif (enable_i = ENABLE and readEnable_i = ENABLE and mode_i = '0') then
+                end if;
+                if (enable_i = ENABLE and readEnable_i = ENABLE and mode_i = '0') then
                     recvAvail <= NO;
                     recvData <= (others => '0');
                 end if;
 
-                if (enable_i = ENABLE and readEnable_i = DISABLE and txdBusy_i = '0') then
-                    -- If busy, ignore it
-                    txdStart_o <= '1';
-                    txdData_o <= dataSave_i(7 downto 0);
+                if (enable_i = ENABLE and readEnable_i = DISABLE) then
+                    if (mode_i = '1') then
+                        txIRE <= dataSave_i(TX_IRE);
+                        rxIRE <= dataSave_i(RX_IRE);
+                    elsif (txdBusy_i = '0') then -- mode_i = '0'
+                        -- If busy, ignore it
+                        txdStart_o <= '1';
+                        txdData_o <= dataSave_i(7 downto 0);
+                    end if;
                 end if;
             end if;
         end if;


### PR DESCRIPTION
按照[张宇翔Linux的串口驱动的描述](https://git.net9.org/shanker/linux-naivemips/wikis/final#223-%E9%A9%B1%E5%8A%A8%E5%BC%80%E5%8F%91)，增加了串口控制地址的第3和第4位，分别用于使能字节发送完毕时的中断，和字节到达时的中断。

改动与原协议兼容，已确认依然能运行μCore。

改动后运行Linux的状况无变化，输出依然是乱序的。