### PR TITLE
修复非对齐访存

### DIFF
--- a/sim/output/loadstore/loadstore4/loadstore4_tb.vhd
+++ b/sim/output/loadstore/loadstore4/loadstore4_tb.vhd
@@ -89,37 +89,37 @@ alias user_reg is <<signal ^.cpu_ist.datapath_ist.regfile_ist.regArray: RegArray
 process begin
     wait for CLK_PERIOD; -- resetting
     wait for 15 * CLK_PERIOD;
-    assert user_reg(4) = x"000000ef" severity FAILURE;
+    assert user_reg(4) = x"ef000000" severity FAILURE;
     wait;
 end process;
 process begin
     wait for CLK_PERIOD; -- resetting
     wait for 17 * CLK_PERIOD;
-    assert user_reg(4) = x"012345ef" severity FAILURE;
+    assert user_reg(4) = x"ef012345" severity FAILURE;
     wait;
 end process;
 process begin
     wait for CLK_PERIOD; -- resetting
     wait for 21 * CLK_PERIOD;
-    assert user_reg(4) = x"0000cdef" severity FAILURE;
+    assert user_reg(4) = x"cdef0000" severity FAILURE;
     wait;
 end process;
 process begin
     wait for CLK_PERIOD; -- resetting
     wait for 23 * CLK_PERIOD;
-    assert user_reg(4) = x"0123cdef" severity FAILURE;
+    assert user_reg(4) = x"cdef0123" severity FAILURE;
     wait;
 end process;
 process begin
     wait for CLK_PERIOD; -- resetting
     wait for 27 * CLK_PERIOD;
-    assert user_reg(4) = x"01000000" severity FAILURE;
+    assert user_reg(4) = x"00000001" severity FAILURE;
     wait;
 end process;
 process begin
     wait for CLK_PERIOD; -- resetting
     wait for 29 * CLK_PERIOD;
-    assert user_reg(4) = x"01abcdef" severity FAILURE;
+    assert user_reg(4) = x"abcdef01" severity FAILURE;
     wait;
 end process;
 process begin

--- a/sim/output/loadstore/loadstore5/loadstore5_tb.vhd
+++ b/sim/output/loadstore/loadstore5/loadstore5_tb.vhd
@@ -101,37 +101,37 @@ end process;
 process begin
     wait for CLK_PERIOD; -- resetting
     wait for 32 * CLK_PERIOD;
-    assert user_reg(6) = x"012345ff" severity FAILURE;
+    assert user_reg(6) = x"234567ff" severity FAILURE;
     wait;
 end process;
 process begin
     wait for CLK_PERIOD; -- resetting
     wait for 33 * CLK_PERIOD;
-    assert user_reg(7) = x"ffffffef" severity FAILURE;
+    assert user_reg(7) = x"ffffff89" severity FAILURE;
     wait;
 end process;
 process begin
     wait for CLK_PERIOD; -- resetting
     wait for 44 * CLK_PERIOD;
-    assert user_reg(6) = x"0123ffff" severity FAILURE;
+    assert user_reg(6) = x"4567ffff" severity FAILURE;
     wait;
 end process;
 process begin
     wait for CLK_PERIOD; -- resetting
     wait for 45 * CLK_PERIOD;
-    assert user_reg(7) = x"ffffcdef" severity FAILURE;
+    assert user_reg(7) = x"ffff89ab" severity FAILURE;
     wait;
 end process;
 process begin
     wait for CLK_PERIOD; -- resetting
     wait for 56 * CLK_PERIOD;
-    assert user_reg(6) = x"01ffffff" severity FAILURE;
+    assert user_reg(6) = x"67ffffff" severity FAILURE;
     wait;
 end process;
 process begin
     wait for CLK_PERIOD; -- resetting
     wait for 57 * CLK_PERIOD;
-    assert user_reg(7) = x"ffabcdef" severity FAILURE;
+    assert user_reg(7) = x"ff89abcd" severity FAILURE;
     wait;
 end process;
     end block assertBlk;

--- a/sim/source/loadstore/loadstore4
+++ b/sim/source/loadstore/loadstore4
@@ -24,21 +24,21 @@ RUN sw  $3, 0x104($10)
 
 RUN or  $4, $0, $0
 RUN lwl $4, 0x104($10)
-ASSERT 15 reg(4) x"000000ef"
+ASSERT 15 reg(4) x"ef000000"
 RUN lwr $4, 0x101($10)
-ASSERT 17 reg(4) x"012345ef"
+ASSERT 17 reg(4) x"ef012345"
 
 RUN or  $4, $0, $0
 RUN lwl $4, 0x105($10)
-ASSERT 21 reg(4) x"0000cdef"
+ASSERT 21 reg(4) x"cdef0000"
 RUN lwr $4, 0x102($10)
-ASSERT 23 reg(4) x"0123cdef"
+ASSERT 23 reg(4) x"cdef0123"
 
 RUN or  $4, $0, $0
 RUN lwr $4, 0x103($10)
-ASSERT 27 reg(4) x"01000000"
+ASSERT 27 reg(4) x"00000001"
 RUN lwl $4, 0x106($10)
-ASSERT 29 reg(4) x"01abcdef"
+ASSERT 29 reg(4) x"abcdef01"
 
 RUN lwl $4, 0x103($10)
 ASSERT 31 reg(4) x"01234567"

--- a/sim/source/loadstore/loadstore5
+++ b/sim/source/loadstore/loadstore5
@@ -36,8 +36,8 @@ RUN swr $4, 0x101($10)
 RUN swl $5, 0x104($10)
 RUN lw $6, 0x100($10)
 RUN lw $7, 0x104($10)
-ASSERT 32 reg(6) x"012345ff"
-ASSERT 33 reg(7) x"ffffffef"
+ASSERT 32 reg(6) x"234567ff"
+ASSERT 33 reg(7) x"ffffff89"
 
 RUN sw $3, 0x100($10)
 RUN sw $3, 0x104($10)
@@ -45,8 +45,8 @@ RUN swr $4, 0x102($10)
 RUN swl $5, 0x105($10)
 RUN lw $6, 0x100($10)
 RUN lw $7, 0x104($10)
-ASSERT 44 reg(6) x"0123ffff"
-ASSERT 45 reg(7) x"ffffcdef"
+ASSERT 44 reg(6) x"4567ffff"
+ASSERT 45 reg(7) x"ffff89ab"
 
 RUN sw $3, 0x100($10)
 RUN sw $3, 0x104($10)
@@ -54,8 +54,8 @@ RUN swr $4, 0x103($10)
 RUN swl $5, 0x106($10)
 RUN lw $6, 0x100($10)
 RUN lw $7, 0x104($10)
-ASSERT 56 reg(6) x"01ffffff"
-ASSERT 57 reg(7) x"ffabcdef"
+ASSERT 56 reg(6) x"67ffffff"
+ASSERT 57 reg(7) x"ff89abcd"
 
 # IF    | ID    | EX    | MEM   | WB    | assertion | period (*=assertion)
 # lui   |       |       |       |       |           | 1

--- a/src/mem.vhd
+++ b/src/mem.vhd
@@ -81,7 +81,6 @@ begin
     process(all)
         variable loadedByte: std_logic_vector(7 downto 0);
         variable loadedShort: std_logic_vector(15 downto 0);
-        variable loadedMask: std_logic_vector(31 downto 0);
     begin
         savingData_o <= (others => '0');
         dataEnable_o <= DISABLE;
@@ -89,7 +88,6 @@ begin
         dataByteSelect_o <= "0000";
         loadedByte := (others => '0');
         loadedShort := (others => '0');
-        loadedMask := (others => '0');
 
         if (rst = RST_ENABLE) then
             toWriteReg_o <= NO;
@@ -129,22 +127,26 @@ begin
                 -- Byte selection --
                 case memt_i is
                     when MEM_LW|MEM_SW|MEM_LL|MEM_SC =>
+                        writeRegData_o <= loadedData_i;
                         savingData_o <= memData_i;
                         dataByteSelect_o <= "1111";
                     when MEM_LWL|MEM_SWL =>
-                        savingData_o <= memData_i;
                         case memAddr_i(1 downto 0) is
                             when "00" =>
-                                loadedMask := 32ux"00_00_00_ff";
+                                writeRegData_o <= loadedData_i(7 downto 0) & memData_i(23 downto 0);
+                                savingData_o <= 24ub"0" & memData_i(31 downto 24);
                                 dataByteSelect_o <= "0001"; -- Read this from right(low) to left(high)!!
                             when "01" =>
-                                loadedMask := 32ux"00_00_ff_ff";
+                                writeRegData_o <= loadedData_i(15 downto 0) & memData_i(15 downto 0);
+                                savingData_o <= 16ub"0" & memData_i(31 downto 16);
                                 dataByteSelect_o <= "0011";
                             when "10" =>
-                                loadedMask := 32ux"00_ff_ff_ff";
+                                writeRegData_o <= loadedData_i(23 downto 0) & memData_i(7 downto 0);
+                                savingData_o <= 8ub"0" & memData_i(31 downto 8);
                                 dataByteSelect_o <= "0111";
                             when "11" =>
-                                loadedMask := 32ux"ff_ff_ff_ff";
+                                writeRegData_o <= loadedData_i;
+                                savingData_o <= memData_i;
                                 dataByteSelect_o <= "1111";
                             when others =>
                                 -- Although there is actually no other cases
@@ -152,19 +154,22 @@ begin
                                 null;
                         end case;
                     when MEM_LWR|MEM_SWR =>
-                        savingData_o <= memData_i;
                         case memAddr_i(1 downto 0) is
                             when "00" =>
-                                loadedMask := 32ux"ff_ff_ff_ff";
+                                writeRegData_o <= loadedData_i;
+                                savingData_o <= memData_i;
                                 dataByteSelect_o <= "1111";
                             when "01" =>
-                                loadedMask := 32ux"ff_ff_ff_00";
+                                writeRegData_o <= memData_i(31 downto 24) & loadedData_i(31 downto 8);
+                                savingData_o <= memData_i(23 downto 0) & 8ub"0";
                                 dataByteSelect_o <= "1110";
                             when "10" =>
-                                loadedMask := 32ux"ff_ff_00_00";
+                                writeRegData_o <= memData_i(31 downto 16) & loadedData_i(31 downto 16);
+                                savingData_o <= memData_i(15 downto 0) & 16ub"0";
                                 dataByteSelect_o <= "1100";
                             when "11" =>
-                                loadedMask := 32ux"ff_00_00_00";
+                                writeRegData_o <= memData_i(31 downto 8) & loadedData_i(31 downto 24);
+                                savingData_o <= memData_i(7 downto 0) & 24ub"0";
                                 dataByteSelect_o <= "1000";
                             when others =>
                                 null;
@@ -217,11 +222,7 @@ begin
                     when MEM_LHU =>
                         writeRegData_o <= std_logic_vector(resize(unsigned(loadedShort), 32));
                         dataEnable_o <= ENABLE;
-                    when MEM_LW|MEM_LL =>
-                        writeRegData_o <= loadedData_i;
-                        dataEnable_o <= ENABLE;
-                    when MEM_LWL|MEM_LWR =>
-                        writeRegData_o <= (loadedData_i and loadedMask) or (memData_i and not loadedMask);
+                    when MEM_LW|MEM_LL|MEM_LWL|MEM_LWR =>
                         dataEnable_o <= ENABLE;
                     when MEM_SB|MEM_SH|MEM_SW|MEM_SWL|MEM_SWR =>
                         dataWrite <= YES;


### PR DESCRIPTION
原来对其行为理解有误。我已经不止一次理解有误了，我也说不清误在哪。个人认为小端序非对齐访存非常绕，所以我就不在这解释了，请大家看文档:(

现在Linux可以正常打印log了。