### PR TITLE
分离的指令缓存和数据缓存

### DIFF
--- a/hard_tests_gen/build.py
+++ b/hard_tests_gen/build.py
@@ -76,11 +76,14 @@ def genImports(importCmd):
 
 def genConfigs(configCmd):
     stmts = ['-- CODE BELOW IS AUTOMATICALLY GENERATED']
+    pairs = {'CPU2_ON': 0, 'ENABLE_CACHE': 0}
     for item in configCmd:
-        if item.upper() == 'CPU2_ON':
-            stmts.append("cpu2On <= '1';")
+        if item.upper() in pairs:
+            pairs[item.upper()] = 1
         else:
             raise Exception("Unrecognized config '%s'"%(item))
+    for key in pairs:
+        stmts.append("constant %s: std_logic := '%d';"%(key, pairs[key]))
     return '\n'.join(stmts)
 
 ''' Parse test file and return (RUN instructions, ASSERT (period #,signal,literal), DEFINE (alias,reference) '''

--- a/hard_tests_gen/template/tb.vhd
+++ b/hard_tests_gen/template/tb.vhd
@@ -21,7 +21,10 @@ architecture bhv of {{{TEST_NAME}}}_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -57,6 +60,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -82,6 +87,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -119,6 +126,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/hard_tests_gen/template/tb.vhd
+++ b/hard_tests_gen/template/tb.vhd
@@ -17,18 +17,19 @@ architecture bhv of {{{TEST_NAME}}}_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    {{{CONFIGS}}}
 begin
     ram_ist: entity work.{{{TEST_NAME}}}_fake_ram
         port map (
@@ -46,7 +47,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -54,6 +56,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -69,14 +72,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -113,6 +118,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -124,11 +131,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        {{{CONFIGS}}}
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/arith/arith1/arith1_tb.vhd
+++ b/sim/output/arith/arith1/arith1_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of arith1_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/arith/arith1/arith1_tb.vhd
+++ b/sim/output/arith/arith1/arith1_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of arith1_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.arith1_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/arith/arith2/arith2_tb.vhd
+++ b/sim/output/arith/arith2/arith2_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of arith2_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of arith2_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant ENABLE_CACHE: std_logic := '0';
 constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.arith2_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/arith/arith2/arith2_tb.vhd
+++ b/sim/output/arith/arith2/arith2_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of arith2_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.arith2_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/arith/arith3/arith3_tb.vhd
+++ b/sim/output/arith/arith3/arith3_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of arith3_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.arith3_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/arith/arith3/arith3_tb.vhd
+++ b/sim/output/arith/arith3/arith3_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of arith3_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of arith3_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant ENABLE_CACHE: std_logic := '0';
 constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.arith3_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/arith/arith4/arith4_tb.vhd
+++ b/sim/output/arith/arith4/arith4_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of arith4_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of arith4_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant CPU2_ON: std_logic := '0';
 constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.arith4_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/arith/arith4/arith4_tb.vhd
+++ b/sim/output/arith/arith4/arith4_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of arith4_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.arith4_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/arith/arith5/arith5_tb.vhd
+++ b/sim/output/arith/arith5/arith5_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of arith5_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of arith5_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant CPU2_ON: std_logic := '0';
 constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.arith5_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/arith/arith5/arith5_tb.vhd
+++ b/sim/output/arith/arith5/arith5_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of arith5_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.arith5_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/arith/arith6/arith6_tb.vhd
+++ b/sim/output/arith/arith6/arith6_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of arith6_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/arith/arith6/arith6_tb.vhd
+++ b/sim/output/arith/arith6/arith6_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of arith6_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.arith6_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/arith/arith7/arith7_tb.vhd
+++ b/sim/output/arith/arith7/arith7_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of arith7_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of arith7_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant ENABLE_CACHE: std_logic := '0';
 constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.arith7_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/arith/arith7/arith7_tb.vhd
+++ b/sim/output/arith/arith7/arith7_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of arith7_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.arith7_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/cp0/cp0_config_default/cp0_config_default_tb.vhd
+++ b/sim/output/cp0/cp0_config_default/cp0_config_default_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of cp0_config_default_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.cp0_config_default_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/cp0/cp0_config_default/cp0_config_default_tb.vhd
+++ b/sim/output/cp0/cp0_config_default/cp0_config_default_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of cp0_config_default_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/cp0/cp0_test/cp0_test_tb.vhd
+++ b/sim/output/cp0/cp0_test/cp0_test_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of cp0_test_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.cp0_test_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/cp0/cp0_test/cp0_test_tb.vhd
+++ b/sim/output/cp0/cp0_test/cp0_test_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of cp0_test_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -32,8 +35,8 @@ architecture bhv of cp0_test_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant CPU2_ON: std_logic := '0';
 constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.cp0_test_fake_ram
         port map (
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/debugpoint/debugpoint_deret/debugpoint_deret_tb.vhd
+++ b/sim/output/debugpoint/debugpoint_deret/debugpoint_deret_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of debugpoint_deret_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/debugpoint/debugpoint_deret/debugpoint_deret_tb.vhd
+++ b/sim/output/debugpoint/debugpoint_deret/debugpoint_deret_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of debugpoint_deret_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.debugpoint_deret_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/debugpoint/debugpoint_iFetch/debugpoint_iFetch_tb.vhd
+++ b/sim/output/debugpoint/debugpoint_iFetch/debugpoint_iFetch_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of debugpoint_iFetch_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.debugpoint_iFetch_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/debugpoint/debugpoint_iFetch/debugpoint_iFetch_tb.vhd
+++ b/sim/output/debugpoint/debugpoint_iFetch/debugpoint_iFetch_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of debugpoint_iFetch_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of debugpoint_iFetch_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant ENABLE_CACHE: std_logic := '0';
 constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.debugpoint_iFetch_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/debugpoint/debugpoint_load/debugpoint_load_tb.vhd
+++ b/sim/output/debugpoint/debugpoint_load/debugpoint_load_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of debugpoint_load_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of debugpoint_load_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant ENABLE_CACHE: std_logic := '0';
 constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.debugpoint_load_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/debugpoint/debugpoint_load/debugpoint_load_tb.vhd
+++ b/sim/output/debugpoint/debugpoint_load/debugpoint_load_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of debugpoint_load_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.debugpoint_load_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/debugpoint/debugpoint_pending/debugpoint_pending_tb.vhd
+++ b/sim/output/debugpoint/debugpoint_pending/debugpoint_pending_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of debugpoint_pending_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of debugpoint_pending_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant CPU2_ON: std_logic := '0';
 constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.debugpoint_pending_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/debugpoint/debugpoint_pending/debugpoint_pending_tb.vhd
+++ b/sim/output/debugpoint/debugpoint_pending/debugpoint_pending_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of debugpoint_pending_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.debugpoint_pending_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/debugpoint/debugpoint_store/debugpoint_store_tb.vhd
+++ b/sim/output/debugpoint/debugpoint_store/debugpoint_store_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of debugpoint_store_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.debugpoint_store_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/debugpoint/debugpoint_store/debugpoint_store_tb.vhd
+++ b/sim/output/debugpoint/debugpoint_store/debugpoint_store_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of debugpoint_store_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/debugpoint/debugpoint_w1c/debugpoint_w1c_tb.vhd
+++ b/sim/output/debugpoint/debugpoint_w1c/debugpoint_w1c_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of debugpoint_w1c_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/debugpoint/debugpoint_w1c/debugpoint_w1c_tb.vhd
+++ b/sim/output/debugpoint/debugpoint_w1c/debugpoint_w1c_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of debugpoint_w1c_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.debugpoint_w1c_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/ehb/ehb/ehb_tb.vhd
+++ b/sim/output/ehb/ehb/ehb_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of ehb_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.ehb_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/ehb/ehb/ehb_tb.vhd
+++ b/sim/output/ehb/ehb/ehb_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of ehb_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -32,8 +35,8 @@ architecture bhv of ehb_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant CPU2_ON: std_logic := '0';
 constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.ehb_fake_ram
         port map (
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/exception/exception_test/exception_test_tb.vhd
+++ b/sim/output/exception/exception_test/exception_test_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of exception_test_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.exception_test_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/exception/exception_test/exception_test_tb.vhd
+++ b/sim/output/exception/exception_test/exception_test_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of exception_test_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/exception/tne1/tne1_tb.vhd
+++ b/sim/output/exception/tne1/tne1_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of tne1_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/exception/tne1/tne1_tb.vhd
+++ b/sim/output/exception/tne1/tne1_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of tne1_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.tne1_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/exception/tne2/tne2_tb.vhd
+++ b/sim/output/exception/tne2/tne2_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of tne2_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.tne2_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/exception/tne2/tne2_tb.vhd
+++ b/sim/output/exception/tne2/tne2_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of tne2_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -32,8 +35,8 @@ architecture bhv of tne2_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant ENABLE_CACHE: std_logic := '0';
 constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.tne2_fake_ram
         port map (
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/jump/branch_likely1/branch_likely1_tb.vhd
+++ b/sim/output/jump/branch_likely1/branch_likely1_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of branch_likely1_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/jump/branch_likely1/branch_likely1_tb.vhd
+++ b/sim/output/jump/branch_likely1/branch_likely1_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of branch_likely1_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.branch_likely1_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/jump/jump1/jump1_tb.vhd
+++ b/sim/output/jump/jump1/jump1_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of jump1_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.jump1_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/jump/jump1/jump1_tb.vhd
+++ b/sim/output/jump/jump1/jump1_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of jump1_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/jump/jump2/jump2_tb.vhd
+++ b/sim/output/jump/jump2/jump2_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of jump2_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -32,8 +35,8 @@ architecture bhv of jump2_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant CPU2_ON: std_logic := '0';
 constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.jump2_fake_ram
         port map (
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/jump/jump2/jump2_tb.vhd
+++ b/sim/output/jump/jump2/jump2_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of jump2_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.jump2_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/jump/jump3/jump3_tb.vhd
+++ b/sim/output/jump/jump3/jump3_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of jump3_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.jump3_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/jump/jump3/jump3_tb.vhd
+++ b/sim/output/jump/jump3/jump3_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of jump3_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/jump/jump4/jump4_tb.vhd
+++ b/sim/output/jump/jump4/jump4_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of jump4_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/jump/jump4/jump4_tb.vhd
+++ b/sim/output/jump/jump4/jump4_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of jump4_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.jump4_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/jump/jump5/jump5_tb.vhd
+++ b/sim/output/jump/jump5/jump5_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of jump5_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/jump/jump5/jump5_tb.vhd
+++ b/sim/output/jump/jump5/jump5_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of jump5_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.jump5_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/jump/jump6/jump6_tb.vhd
+++ b/sim/output/jump/jump6/jump6_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of jump6_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -32,8 +35,8 @@ architecture bhv of jump6_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant CPU2_ON: std_logic := '0';
 constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.jump6_fake_ram
         port map (
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/jump/jump6/jump6_tb.vhd
+++ b/sim/output/jump/jump6/jump6_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of jump6_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.jump6_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/jump/jump7/jump7_tb.vhd
+++ b/sim/output/jump/jump7/jump7_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of jump7_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/jump/jump7/jump7_tb.vhd
+++ b/sim/output/jump/jump7/jump7_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of jump7_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.jump7_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/loadstore/loadstore1/loadstore1_tb.vhd
+++ b/sim/output/loadstore/loadstore1/loadstore1_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of loadstore1_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.loadstore1_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/loadstore/loadstore1/loadstore1_tb.vhd
+++ b/sim/output/loadstore/loadstore1/loadstore1_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of loadstore1_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/loadstore/loadstore2/loadstore2_tb.vhd
+++ b/sim/output/loadstore/loadstore2/loadstore2_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of loadstore2_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -32,8 +35,8 @@ architecture bhv of loadstore2_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant ENABLE_CACHE: std_logic := '0';
 constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.loadstore2_fake_ram
         port map (
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/loadstore/loadstore2/loadstore2_tb.vhd
+++ b/sim/output/loadstore/loadstore2/loadstore2_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of loadstore2_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.loadstore2_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/loadstore/loadstore3/loadstore3_tb.vhd
+++ b/sim/output/loadstore/loadstore3/loadstore3_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of loadstore3_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/loadstore/loadstore3/loadstore3_tb.vhd
+++ b/sim/output/loadstore/loadstore3/loadstore3_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of loadstore3_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.loadstore3_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/loadstore/loadstore4/loadstore4_tb.vhd
+++ b/sim/output/loadstore/loadstore4/loadstore4_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of loadstore4_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/loadstore/loadstore4/loadstore4_tb.vhd
+++ b/sim/output/loadstore/loadstore4/loadstore4_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of loadstore4_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.loadstore4_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/loadstore/loadstore5/loadstore5_tb.vhd
+++ b/sim/output/loadstore/loadstore5/loadstore5_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of loadstore5_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.loadstore5_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/loadstore/loadstore5/loadstore5_tb.vhd
+++ b/sim/output/loadstore/loadstore5/loadstore5_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of loadstore5_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/loadstore/loadstore_stall/loadstore_stall_tb.vhd
+++ b/sim/output/loadstore/loadstore_stall/loadstore_stall_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of loadstore_stall_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.loadstore_stall_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/loadstore/loadstore_stall/loadstore_stall_tb.vhd
+++ b/sim/output/loadstore/loadstore_stall/loadstore_stall_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of loadstore_stall_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/loadstore/loadstore_stall2/loadstore_stall2_tb.vhd
+++ b/sim/output/loadstore/loadstore_stall2/loadstore_stall2_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of loadstore_stall2_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.loadstore_stall2_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/loadstore/loadstore_stall2/loadstore_stall2_tb.vhd
+++ b/sim/output/loadstore/loadstore_stall2/loadstore_stall2_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of loadstore_stall2_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/logic/logic1/logic1_tb.vhd
+++ b/sim/output/logic/logic1/logic1_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of logic1_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -32,8 +35,8 @@ architecture bhv of logic1_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant ENABLE_CACHE: std_logic := '0';
 constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.logic1_fake_ram
         port map (
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/logic/logic1/logic1_tb.vhd
+++ b/sim/output/logic/logic1/logic1_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of logic1_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.logic1_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/logic/logic2/logic2_tb.vhd
+++ b/sim/output/logic/logic2/logic2_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of logic2_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.logic2_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/logic/logic2/logic2_tb.vhd
+++ b/sim/output/logic/logic2/logic2_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of logic2_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/logic/logic3/logic3_tb.vhd
+++ b/sim/output/logic/logic3/logic3_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of logic3_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -32,8 +35,8 @@ architecture bhv of logic3_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant CPU2_ON: std_logic := '0';
 constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.logic3_fake_ram
         port map (
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/logic/logic3/logic3_tb.vhd
+++ b/sim/output/logic/logic3/logic3_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of logic3_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.logic3_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/logici/logici1/logici1_tb.vhd
+++ b/sim/output/logici/logici1/logici1_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of logici1_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/logici/logici1/logici1_tb.vhd
+++ b/sim/output/logici/logici1/logici1_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of logici1_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.logici1_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/mov/mov1/mov1_tb.vhd
+++ b/sim/output/mov/mov1/mov1_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of mov1_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/mov/mov1/mov1_tb.vhd
+++ b/sim/output/mov/mov1/mov1_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of mov1_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.mov1_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/mov/mov2/mov2_tb.vhd
+++ b/sim/output/mov/mov2/mov2_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of mov2_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of mov2_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant ENABLE_CACHE: std_logic := '0';
 constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.mov2_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/mov/mov2/mov2_tb.vhd
+++ b/sim/output/mov/mov2/mov2_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of mov2_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.mov2_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/mov/mov3/mov3_tb.vhd
+++ b/sim/output/mov/mov3/mov3_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of mov3_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of mov3_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant CPU2_ON: std_logic := '0';
 constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.mov3_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/mov/mov3/mov3_tb.vhd
+++ b/sim/output/mov/mov3/mov3_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of mov3_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.mov3_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/multicore/multicore1/multicore1_tb.vhd
+++ b/sim/output/multicore/multicore1/multicore1_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of multicore1_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '1';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.multicore1_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,12 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-cpu2On <= '1';
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/multicore/multicore1/multicore1_tb.vhd
+++ b/sim/output/multicore/multicore1/multicore1_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of multicore1_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/multicore/multicore2/multicore2_tb.vhd
+++ b/sim/output/multicore/multicore2/multicore2_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of multicore2_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -32,8 +35,8 @@ architecture bhv of multicore2_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant CPU2_ON: std_logic := '1';
 constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '1';
 begin
     ram_ist: entity work.multicore2_fake_ram
         port map (
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/multicore/multicore2/multicore2_tb.vhd
+++ b/sim/output/multicore/multicore2/multicore2_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of multicore2_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '1';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.multicore2_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,12 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-cpu2On <= '1';
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/multicore/multicore_boot1/multicore_boot1_tb.vhd
+++ b/sim/output/multicore/multicore_boot1/multicore_boot1_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of multicore_boot1_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -32,8 +35,8 @@ architecture bhv of multicore_boot1_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant ENABLE_CACHE: std_logic := '0';
 constant CPU2_ON: std_logic := '1';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.multicore_boot1_fake_ram
         port map (
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/multicore/multicore_boot1/multicore_boot1_tb.vhd
+++ b/sim/output/multicore/multicore_boot1/multicore_boot1_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of multicore_boot1_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '1';
 begin
     ram_ist: entity work.multicore_boot1_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,12 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-cpu2On <= '1';
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/nop_equivalents/nop_equivalents/nop_equivalents_tb.vhd
+++ b/sim/output/nop_equivalents/nop_equivalents/nop_equivalents_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of nop_equivalents_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.nop_equivalents_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/nop_equivalents/nop_equivalents/nop_equivalents_tb.vhd
+++ b/sim/output/nop_equivalents/nop_equivalents/nop_equivalents_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of nop_equivalents_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/ori/ori1/ori1_tb.vhd
+++ b/sim/output/ori/ori1/ori1_tb.vhd
@@ -19,18 +19,21 @@ architecture bhv of ori1_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.ori1_fake_ram
         port map (
@@ -48,7 +51,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -56,6 +60,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -71,14 +76,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -115,6 +122,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -126,11 +135,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/ori/ori1/ori1_tb.vhd
+++ b/sim/output/ori/ori1/ori1_tb.vhd
@@ -23,7 +23,10 @@ architecture bhv of ori1_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -61,6 +64,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -86,6 +91,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -123,6 +130,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/ori/ori2/ori2_tb.vhd
+++ b/sim/output/ori/ori2/ori2_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of ori2_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.ori2_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/ori/ori2/ori2_tb.vhd
+++ b/sim/output/ori/ori2/ori2_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of ori2_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of ori2_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant ENABLE_CACHE: std_logic := '0';
 constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.ori2_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/overall/overall1/overall1_tb.vhd
+++ b/sim/output/overall/overall1/overall1_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of overall1_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/overall/overall1/overall1_tb.vhd
+++ b/sim/output/overall/overall1/overall1_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of overall1_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.overall1_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/overall/overall2/overall2_tb.vhd
+++ b/sim/output/overall/overall2/overall2_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of overall2_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.overall2_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/overall/overall2/overall2_tb.vhd
+++ b/sim/output/overall/overall2/overall2_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of overall2_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of overall2_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant ENABLE_CACHE: std_logic := '0';
 constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.overall2_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/sync/sync1/sync1_tb.vhd
+++ b/sim/output/sync/sync1/sync1_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of sync1_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of sync1_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant CPU2_ON: std_logic := '0';
 constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.sync1_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/sync/sync1/sync1_tb.vhd
+++ b/sim/output/sync/sync1/sync1_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of sync1_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.sync1_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/sync/sync2/sync2_tb.vhd
+++ b/sim/output/sync/sync2/sync2_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of sync2_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/sync/sync2/sync2_tb.vhd
+++ b/sim/output/sync/sync2/sync2_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of sync2_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.sync2_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/tlb/tlb1/tlb1_tb.vhd
+++ b/sim/output/tlb/tlb1/tlb1_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of tlb1_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.tlb1_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/tlb/tlb1/tlb1_tb.vhd
+++ b/sim/output/tlb/tlb1/tlb1_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of tlb1_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of tlb1_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant CPU2_ON: std_logic := '0';
 constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.tlb1_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/tlb/tlb_dirty/tlb_dirty_tb.vhd
+++ b/sim/output/tlb/tlb_dirty/tlb_dirty_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of tlb_dirty_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.tlb_dirty_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/tlb/tlb_dirty/tlb_dirty_tb.vhd
+++ b/sim/output/tlb/tlb_dirty/tlb_dirty_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of tlb_dirty_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/tlb/tlb_pagemask/tlb_pagemask_tb.vhd
+++ b/sim/output/tlb/tlb_pagemask/tlb_pagemask_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of tlb_pagemask_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.tlb_pagemask_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/tlb/tlb_pagemask/tlb_pagemask_tb.vhd
+++ b/sim/output/tlb/tlb_pagemask/tlb_pagemask_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of tlb_pagemask_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of tlb_pagemask_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant CPU2_ON: std_logic := '0';
 constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.tlb_pagemask_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/tlb/tlb_tlbp/tlb_tlbp_tb.vhd
+++ b/sim/output/tlb/tlb_tlbp/tlb_tlbp_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of tlb_tlbp_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.tlb_tlbp_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/tlb/tlb_tlbp/tlb_tlbp_tb.vhd
+++ b/sim/output/tlb/tlb_tlbp/tlb_tlbp_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of tlb_tlbp_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of tlb_tlbp_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant CPU2_ON: std_logic := '0';
 constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.tlb_tlbp_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/tlb/tlb_tlbr/tlb_tlbr_tb.vhd
+++ b/sim/output/tlb/tlb_tlbr/tlb_tlbr_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of tlb_tlbr_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -31,8 +34,8 @@ architecture bhv of tlb_tlbr_tb is
     signal timerInt1, timerInt2: std_logic;
 
     -- CODE BELOW IS AUTOMATICALLY GENERATED
-constant CPU2_ON: std_logic := '0';
 constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.tlb_tlbr_fake_ram
         port map (
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/tlb/tlb_tlbr/tlb_tlbr_tb.vhd
+++ b/sim/output/tlb/tlb_tlbr/tlb_tlbr_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of tlb_tlbr_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.tlb_tlbr_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/tlb/tlb_valid/tlb_valid_tb.vhd
+++ b/sim/output/tlb/tlb_valid/tlb_valid_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of tlb_valid_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/sim/output/tlb/tlb_valid/tlb_valid_tb.vhd
+++ b/sim/output/tlb/tlb_valid/tlb_valid_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of tlb_valid_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant CPU2_ON: std_logic := '0';
+constant ENABLE_CACHE: std_logic := '0';
 begin
     ram_ist: entity work.tlb_valid_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/tlb/tlbinvf/tlbinvf_tb.vhd
+++ b/sim/output/tlb/tlbinvf/tlbinvf_tb.vhd
@@ -18,18 +18,21 @@ architecture bhv of tlbinvf_tb is
     signal rst: std_logic := '1';
     signal clk: std_logic := '0';
 
-    signal cpu2On: std_logic;
-
     signal cpu1Inst_c2d, cpu1Data_c2d, cpu2Inst_c2d, cpu2Data_c2d: BusC2D;
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon_c2d: BusC2D;
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
 
     signal int1, int2: std_logic_vector(IntWidth);
     signal timerInt1, timerInt2: std_logic;
+
+    -- CODE BELOW IS AUTOMATICALLY GENERATED
+constant ENABLE_CACHE: std_logic := '0';
+constant CPU2_ON: std_logic := '0';
 begin
     ram_ist: entity work.tlbinvf_fake_ram
         port map (
@@ -47,7 +50,8 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU1_ID, others => '0')
+            cpuId                   => (0 => CPU1_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
             rst => rst, clk => clk,
@@ -55,6 +59,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -70,14 +75,16 @@ begin
             generalExceptOffset     => 32ux"40",
             interruptIv1Offset      => 32ux"40",
             convEndianEnable        => true,
-            cpuId => (0 => CPU2_ID, others => '0')
+            cpuId                   => (0 => CPU2_ID, others => '0'),
+            enableCache             => ENABLE_CACHE
         )
         port map (
-            rst => rst or not cpu2On, clk => clk,
+            rst => rst or not CPU2_ON, clk => clk,
             instDev_i => cpu2Inst_d2c,
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon_c2d,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -114,6 +121,8 @@ begin
             led_o => led_c2d,
             num_o => num_c2d,
 
+            busMon_o => busMon_c2d,
+
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,
             sync2_i => sync2,
@@ -125,11 +134,6 @@ begin
     eth_d2c.dataLoad <= (others => '0'); eth_d2c.busy <= PIPELINE_STOP;
     led_d2c.dataLoad <= (others => '0'); led_d2c.busy <= PIPELINE_STOP;
     num_d2c.dataLoad <= (others => '0'); num_d2c.busy <= PIPELINE_STOP;
-
-    process (all) begin
-        cpu2On <= '0';
-        -- CODE BELOW IS AUTOMATICALLY GENERATED
-    end process;
 
     process begin
         wait for CLK_PERIOD / 2;

--- a/sim/output/tlb/tlbinvf/tlbinvf_tb.vhd
+++ b/sim/output/tlb/tlbinvf/tlbinvf_tb.vhd
@@ -22,7 +22,10 @@ architecture bhv of tlbinvf_tb is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ram_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ram_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon_c2d: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal sync1, sync2: std_logic_vector(2 downto 0);
     signal scCorrect1, scCorrect2: std_logic;
@@ -60,6 +63,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int1,
             timerInt_o => timerInt1,
             sync_o => sync1,
@@ -85,6 +90,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon_c2d,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             int_i => int2,
             timerInt_o => timerInt2,
             sync_o => sync2,
@@ -122,6 +129,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon_c2d,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/src/cache.vhd
+++ b/src/cache.vhd
@@ -1,0 +1,117 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+use work.global_const.all;
+use work.bus_const.all;
+
+entity cache is
+    generic (
+        enableCache: std_logic
+    );
+    port (
+        clk, rst: in std_logic;
+        vAddr_i: in std_logic_vector(AddrWidth);
+
+        -- From / to CPU
+        req_i: in BusC2D;
+        res_o: out BusD2C;
+
+        -- From / to devices
+        req_o: out BusC2D;
+        res_i: in BusD2C;
+        mon_i: in BusC2D
+    );
+end cache;
+
+architecture bhv of cache is
+    constant OFFSET_WIDTH: integer := 2;
+    constant INDEX_WIDTH: integer := 4;
+    constant TAG_WIDTH: integer := 32 - OFFSET_WIDTH - INDEX_WIDTH;
+
+    constant INDEX_NUM: integer := 2 ** INDEX_WIDTH;
+
+    type CacheItemType is record
+        present: std_logic;
+        tag: std_logic_vector(TAG_WIDTH - 1 downto 0);
+        data: std_logic_vector(DataWidth);
+    end record CacheItemType;
+
+    type CacheTableType is array(0 to INDEX_NUM - 1) of CacheItemType;
+
+    signal table: CacheTableType;
+    signal reqTag, monTag: std_logic_vector(TAG_WIDTH - 1 downto 0);
+    signal reqIndex, monIndex: integer;
+    signal readFromCache: std_logic;
+begin
+
+    readFromCache <= NO when vAddr_i(31 downto 28) >= 4x"a" and vAddr_i(31 downto 28) < 4x"c" else enableCache;
+
+    process (all) begin
+        reqTag <= (others => 'X');
+        reqIndex <= 0; -- Make it not overflow during simulation
+        monTag <= (others => 'X');
+        monIndex <= 0;
+        if (req_i.enable = ENABLE) then
+            reqTag <= req_i.addr(31 downto 32 - TAG_WIDTH);
+            reqIndex <= conv_integer(req_i.addr(31 - TAG_WIDTH downto 32 - TAG_WIDTH - INDEX_WIDTH));
+        end if;
+        if (mon_i.enable = ENABLE) then
+            monTag <= mon_i.addr(31 downto 32 - TAG_WIDTH);
+            monIndex <= conv_integer(mon_i.addr(31 - TAG_WIDTH downto 32 - TAG_WIDTH - INDEX_WIDTH));
+        end if;
+    end process;
+
+    process (all) begin
+        res_o.busy <= PIPELINE_NONSTOP;
+        res_o.dataLoad <= (others => 'X');
+        req_o.enable <= DISABLE;
+        if (req_i.enable = ENABLE) then
+            if (
+                readFromCache = YES and req_i.write = NO and
+                table(reqIndex).tag = reqTag and table(reqIndex).present = '1'
+            ) then
+                res_o.busy <= PIPELINE_NONSTOP;
+                res_o.dataLoad <= table(reqIndex).data;
+            else
+                res_o.busy <= res_i.busy;
+                res_o.dataLoad <= res_i.dataLoad;
+                req_o.enable <= ENABLE;
+            end if;
+        end if;
+    end process;
+    req_o.write <= req_i.enable and req_i.write;
+    req_o.addr <= req_i.addr;
+    req_o.byteSelect <= "1111" when req_i.write = NO else req_i.byteSelect;
+    req_o.dataSave <= req_i.dataSave;
+
+    process (clk) begin
+        if (rising_edge(clk)) then
+            if (rst = RST_ENABLE) then
+                table <= (others => (present => '0', tag => (others => '0'), data => 32ux"0"));
+            else
+                if (mon_i.enable = ENABLE and mon_i.write = YES) then -- Put this before the reading part
+                    if (table(monIndex).present = '1' and table(monIndex).tag = monTag) then
+                        if (mon_i.byteSelect(0) = '1') then
+                            table(monIndex).data(7 downto 0) <= mon_i.dataSave(7 downto 0);
+                        end if;
+                        if (mon_i.byteSelect(1) = '1') then
+                            table(monIndex).data(15 downto 8) <= mon_i.dataSave(15 downto 8);
+                        end if;
+                        if (mon_i.byteSelect(2) = '1') then
+                            table(monIndex).data(23 downto 16) <= mon_i.dataSave(23 downto 16);
+                        end if;
+                        if (mon_i.byteSelect(3) = '1') then
+                            table(monIndex).data(31 downto 24) <= mon_i.dataSave(31 downto 24);
+                        end if;
+                    end if;
+                end if;
+                if (req_i.enable = ENABLE and req_i.write = NO and res_i.busy = PIPELINE_NONSTOP) then
+                    table(reqIndex) <= (present => '1', tag => reqTag, data => res_i.dataLoad);
+                end if;
+            end if;
+        end if;
+    end process;
+
+end bhv;
+

--- a/src/cache.vhd
+++ b/src/cache.vhd
@@ -16,11 +16,14 @@ entity cache is
         -- From / to CPU
         req_i: in BusC2D;
         res_o: out BusD2C;
+        sync_i: in std_logic_vector(2 downto 0);
 
         -- From / to devices
         req_o: out BusC2D;
         res_i: in BusD2C;
-        mon_i: in BusC2D
+        mon_i: in BusC2D;
+        llBit_i: in std_logic;
+        llLoc_i: in std_logic_vector(AddrWidth)
     );
 end cache;
 
@@ -45,7 +48,12 @@ architecture bhv of cache is
     signal readFromCache, satisfied: std_logic;
 begin
 
-    readFromCache <= NO when vAddr_i(31 downto 28) >= 4x"a" and vAddr_i(31 downto 28) < 4x"c" else enableCache;
+    readFromCache <= NO when
+                        (vAddr_i(31 downto 28) >= 4x"a" and vAddr_i(31 downto 28) < 4x"c") or
+                        sync_i /= "000" or
+                        (llBit_i = '1' and llLoc_i = req_i.addr)
+                     else
+                         enableCache;
 
     process (all) begin
         reqTag <= (others => 'X');

--- a/src/cpu.vhd
+++ b/src/cpu.vhd
@@ -22,6 +22,8 @@ entity cpu is
         instDev_i, dataDev_i: in BusD2C;
         instDev_o, dataDev_o: out BusC2D;
         busMon_i: in BusC2D;
+        llBit_i: in std_logic;
+        llLoc_i: in std_logic_vector(AddrWidth);
         scCorrect_i: in std_logic;
         sync_o: out std_logic_vector(2 downto 0);
 
@@ -57,6 +59,7 @@ architecture bhv of cpu is
     signal entrySave, entryLoad: TLBEntry;
     signal pageMask: std_logic_vector(AddrWidth);
 
+    signal sync: std_logic_vector(2 downto 0);
 begin
     inst_cache: entity work.cache
         generic map (
@@ -67,9 +70,12 @@ begin
             vAddr_i => instVAddr,
             req_i => instCache_c2d,
             res_o => instCache_d2c,
+            sync_i => "000",
             req_o => instDev_o,
             res_i => instDev_i,
-            mon_i => busMon_i
+            mon_i => busMon_i,
+            llBit_i => llBit_i,
+            llLoc_i => llLoc_i
         );
     data_cache: entity work.cache
         generic map (
@@ -80,9 +86,12 @@ begin
             vAddr_i => dataVAddr,
             req_i => dataCache_c2d,
             res_o => dataCache_d2c,
+            sync_i => sync,
             req_o => dataDev_o,
             res_i => dataDev_i,
-            mon_i => busMon_i
+            mon_i => busMon_i,
+            llBit_i => llBit_i,
+            llLoc_i => llLoc_i
         );
 
     instCache_c2d.dataSave <= (others => 'X');
@@ -180,7 +189,8 @@ begin
             entry_o => entrySave,
             pageMask_o => pageMask,
             scCorrect_i => scCorrect_i,
-            sync_o => sync_o
+            sync_o => sync
         );
+    sync_o <= sync;
 
 end bhv;

--- a/src/cpu.vhd
+++ b/src/cpu.vhd
@@ -13,13 +13,15 @@ entity cpu is
         generalExceptOffset: std_logic_vector(AddrWidth) := 32ux"180";
         interruptIv1Offset: std_logic_vector(AddrWidth) := 32ux"200";
         convEndianEnable: boolean := false;
-        cpuId: std_logic_vector(9 downto 0) := 10ub"0"
+        cpuId: std_logic_vector(9 downto 0) := 10ub"0";
+        enableCache: std_logic := YES
     );
     port (
         clk, rst: in std_logic;
 
         instDev_i, dataDev_i: in BusD2C;
         instDev_o, dataDev_o: out BusC2D;
+        busMon_i: in BusC2D;
         scCorrect_i: in std_logic;
         sync_o: out std_logic_vector(2 downto 0);
 
@@ -44,6 +46,9 @@ architecture bhv of cpu is
     signal dataExcept: std_logic_vector(ExceptionCauseWidth);
     signal dataTlbRefill: std_logic;
 
+    signal instCache_d2c, dataCache_d2c: BusD2C;
+    signal instCache_c2d, dataCache_c2d: BusC2D;
+
     signal isKernelMode: std_logic;
     signal entryIndexSave, entryIndexLoad: std_logic_vector(TLBIndexWidth);
     signal entryIndexValid: std_logic;
@@ -53,28 +58,55 @@ architecture bhv of cpu is
     signal pageMask: std_logic_vector(AddrWidth);
 
 begin
-    instDev_o.dataSave <= (others => 'X');
+    inst_cache: entity work.cache
+        generic map (
+            enableCache => enableCache
+        )
+        port map (
+            clk => clk, rst => rst,
+            vAddr_i => instVAddr,
+            req_i => instCache_c2d,
+            res_o => instCache_d2c,
+            req_o => instDev_o,
+            res_i => instDev_i,
+            mon_i => busMon_i
+        );
+    data_cache: entity work.cache
+        generic map (
+            enableCache => enableCache
+        )
+        port map (
+            clk => clk, rst => rst,
+            vAddr_i => dataVAddr,
+            req_i => dataCache_c2d,
+            res_o => dataCache_d2c,
+            req_o => dataDev_o,
+            res_i => dataDev_i,
+            mon_i => busMon_i
+        );
+
+    instCache_c2d.dataSave <= (others => 'X');
     conv_endian_inst_load: entity work.conv_endian
         generic map (enable => convEndianEnable)
-        port map (input => instDev_i.dataLoad, output => instData);
+        port map (input => instCache_d2c.dataLoad, output => instData);
     conv_endian_data_save: entity work.conv_endian
         generic map (enable => convEndianEnable)
-        port map (input => dataDataSave, output => dataDev_o.dataSave);
+        port map (input => dataDataSave, output => dataCache_c2d.dataSave);
     conv_endian_data_load: entity work.conv_endian
         generic map (enable => convEndianEnable)
-        port map (input => dataDev_i.dataLoad, output => dataDataLoad);
+        port map (input => dataCache_d2c.dataLoad, output => dataDataLoad);
 
-    instDev_o.byteSelect <= "1111";
+    instCache_c2d.byteSelect <= "1111";
     process (all) begin
         if (convEndianEnable) then
-            dataDev_o.byteSelect <= dataByteSelect(0) & dataByteSelect(1) & dataByteSelect(2) & dataByteSelect(3);
+            dataCache_c2d.byteSelect <= dataByteSelect(0) & dataByteSelect(1) & dataByteSelect(2) & dataByteSelect(3);
         else
-            dataDev_o.byteSelect <= dataByteSelect;
+            dataCache_c2d.byteSelect <= dataByteSelect;
         end if;
     end process;
 
-    instDev_o.write <= NO;
-    dataDev_o.write <= dataWrite;
+    instCache_c2d.write <= NO;
+    dataCache_c2d.write <= dataWrite;
 
     mmu_ist: entity work.mmu
         port map (
@@ -85,16 +117,16 @@ begin
             enable1_i => instEnable,
             isLoad1_i => YES,
             addr1_i => instVAddr,
-            addr1_o => instDev_o.addr,
-            enable1_o => instDev_o.enable,
+            addr1_o => instCache_c2d.addr,
+            enable1_o => instCache_c2d.enable,
             exceptCause1_o => instExcept,
             tlbRefill1_o => instTlbRefill,
 
             enable2_i => dataEnable,
             isLoad2_i => not dataWrite,
             addr2_i => dataVAddr,
-            addr2_o => dataDev_o.addr,
-            enable2_o => dataDev_o.enable,
+            addr2_o => dataCache_c2d.addr,
+            enable2_o => dataCache_c2d.enable,
             exceptCause2_o => dataExcept,
             tlbRefill2_o => dataTlbRefill,
 
@@ -134,8 +166,8 @@ begin
             instExcept_i => instExcept,
             dataExcept_i => dataExcept,
             dataTlbRefill_i => dataTlbRefill,
-            ifToStall_i => instDev_i.busy,
-            memToStall_i => dataDev_i.busy,
+            ifToStall_i => instCache_d2c.busy,
+            memToStall_i => dataCache_d2c.busy,
             int_i => int_i,
             timerInt_o => timerInt_o,
             isKernelMode_o => isKernelMode,

--- a/src/ddr3_ctrl_cache.vhd
+++ b/src/ddr3_ctrl_cache.vhd
@@ -22,12 +22,26 @@ entity ddr3_ctrl_cache is
 end ddr3_ctrl_cache;
 
 architecture bhv of ddr3_ctrl_cache is
+    constant OFFSET_WIDTH: integer := BURST_LEN_WIDTH;
+    constant INDEX_WIDTH: integer := 4;
+    constant TAG_WIDTH: integer := 25 - OFFSET_WIDTH - INDEX_WIDTH;
+
+    constant INDEX_NUM: integer := 2 ** INDEX_WIDTH;
+
+    type CacheItemType is record
+        present: std_logic;
+        tag: std_logic_vector(TAG_WIDTH - 1 downto 0);
+        data: BurstDataType;
+    end record CacheItemType;
+
+    type CacheTableType is array(0 to INDEX_NUM - 1) of CacheItemType;
+
     signal table: CacheTableType;
     signal tag: std_logic_vector(TAG_WIDTH - 1 downto 0);
     signal index, offset: integer;
     signal needToRead: std_logic;
 begin
-    
+
     tag <= addr_i(26 downto 27 - TAG_WIDTH);
     index <= conv_integer(addr_i(26 - TAG_WIDTH downto 27 - TAG_WIDTH - INDEX_WIDTH));
     offset <= conv_integer(addr_i(OFFSET_WIDTH + 1 downto 2));

--- a/src/devctrl.vhd
+++ b/src/devctrl.vhd
@@ -12,7 +12,11 @@ entity devctrl is
         cpu1Inst_o, cpu1Data_o, cpu2Inst_o, cpu2Data_o: out BusD2C;
         ddr3_i, flash_i, serial_i, boot_i, eth_i, led_i, num_i: in BusD2C;
         ddr3_o, flash_o, serial_o, boot_o, eth_o, led_o, num_o: out BusC2D;
+
+        -- Bus monitoring
         busMon_o: out BusC2D;
+        llBit_o: out std_logic;
+        llLoc_o: out std_logic_vector(AddrWidth);
 
         -- for sync --
         sync1_i, sync2_i: in std_logic_vector(2 downto 0);
@@ -164,4 +168,6 @@ begin
             end if;
         end if;
     end process;
+    llBit_o <= llBit;
+    llLoc_o <= llLoc;
 end bhv;

--- a/src/devctrl.vhd
+++ b/src/devctrl.vhd
@@ -12,6 +12,7 @@ entity devctrl is
         cpu1Inst_o, cpu1Data_o, cpu2Inst_o, cpu2Data_o: out BusD2C;
         ddr3_i, flash_i, serial_i, boot_i, eth_i, led_i, num_i: in BusD2C;
         ddr3_o, flash_o, serial_o, boot_o, eth_o, led_o, num_o: out BusC2D;
+        busMon_o: out BusC2D;
 
         -- for sync --
         sync1_i, sync2_i: in std_logic_vector(2 downto 0);
@@ -123,6 +124,7 @@ begin
             scCorrect2_o <= scCorrect;
         end if;
     end process;
+    busMon_o <= conn_c2d;
 
     process (all) begin
         conn_d2c.busy <= PIPELINE_NONSTOP;

--- a/src/packages/ddr3_const.vhd
+++ b/src/packages/ddr3_const.vhd
@@ -3,24 +3,10 @@ use ieee.std_logic_1164.all;
 
 package ddr3_const is
 
-    constant BURST_LEN: integer := 8;
     constant BURST_LEN_WIDTH: integer := 3;
+    constant BURST_LEN: integer := 2 ** BURST_LEN_WIDTH;
 
     subtype BurstLenWidth is integer range BURST_LEN_WIDTH - 1 downto 0;
     type BurstDataType is array(0 to (BURST_LEN - 1)) of std_logic_vector(31 downto 0);
-
-    constant OFFSET_WIDTH: integer := BURST_LEN_WIDTH;
-    constant INDEX_WIDTH: integer := 4;
-    constant TAG_WIDTH: integer := 25 - OFFSET_WIDTH - INDEX_WIDTH;
-
-    constant INDEX_NUM: integer := 16;
-
-    type CacheItemType is record
-        present: std_logic;
-        tag: std_logic_vector(TAG_WIDTH - 1 downto 0);
-        data: BurstDataType;
-    end record CacheItemType;
-
-    type CacheTableType is array(0 to INDEX_NUM - 1) of CacheItemType;
 
 end ddr3_const;

--- a/src/top.vhd
+++ b/src/top.vhd
@@ -142,7 +142,10 @@ architecture bhv of top is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ddr3_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ddr3_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+
     signal busMon: BusC2D;
+    signal llBit: std_logic;
+    signal llLoc: std_logic_vector(AddrWidth);
 
     signal scCorrect1, scCorrect2: std_logic;
     signal sync1, sync2: std_logic_vector(2 downto 0);
@@ -215,6 +218,8 @@ begin
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
             busMon_i => busMon,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             sync_o => sync1,
             scCorrect_i => scCorrect1,
             int_i => irq1,
@@ -237,6 +242,8 @@ begin
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
             busMon_i => busMon,
+            llBit_i => llBit,
+            llLoc_i => llLoc,
             sync_o => sync2,
             scCorrect_i => scCorrect2,
             int_i => irq2,
@@ -273,6 +280,8 @@ begin
             num_o => num_c2d,
 
             busMon_o => busMon,
+            llBit_o => llBit,
+            llLoc_o => llLoc,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/src/top.vhd
+++ b/src/top.vhd
@@ -142,6 +142,7 @@ architecture bhv of top is
     signal cpu1Inst_d2c, cpu1Data_d2c, cpu2Inst_d2c, cpu2Data_d2c: BusD2C;
     signal ddr3_c2d, flash_c2d, serial_c2d, boot_c2d, eth_c2d, led_c2d, num_c2d: BusC2D;
     signal ddr3_d2c, flash_d2c, serial_d2c, boot_d2c, eth_d2c, led_d2c, num_d2c: BusD2C;
+    signal busMon: BusC2D;
 
     signal scCorrect1, scCorrect2: std_logic;
     signal sync1, sync2: std_logic_vector(2 downto 0);
@@ -213,6 +214,7 @@ begin
             dataDev_i => cpu1Data_d2c,
             instDev_o => cpu1Inst_c2d,
             dataDev_o => cpu1Data_c2d,
+            busMon_i => busMon,
             sync_o => sync1,
             scCorrect_i => scCorrect1,
             int_i => irq1,
@@ -234,6 +236,7 @@ begin
             dataDev_i => cpu2Data_d2c,
             instDev_o => cpu2Inst_c2d,
             dataDev_o => cpu2Data_c2d,
+            busMon_i => busMon,
             sync_o => sync2,
             scCorrect_i => scCorrect2,
             int_i => irq2,
@@ -268,6 +271,8 @@ begin
             eth_o => eth_c2d,
             led_o => led_c2d,
             num_o => num_c2d,
+
+            busMon_o => busMon,
 
             sync1_i => sync1,
             scCorrect1_o => scCorrect1,

--- a/thinpad_top/thinpad_top.xpr
+++ b/thinpad_top/thinpad_top.xpr
@@ -30,7 +30,7 @@
     <Option Name="EnableBDX" Val="FALSE"/>
     <Option Name="DSANumComputeUnits" Val="16"/>
     <Option Name="WTXSimLaunchSim" Val="179"/>
-    <Option Name="WTModelSimLaunchSim" Val="69"/>
+    <Option Name="WTModelSimLaunchSim" Val="70"/>
     <Option Name="WTQuestaLaunchSim" Val="0"/>
     <Option Name="WTIesLaunchSim" Val="0"/>
     <Option Name="WTVcsLaunchSim" Val="0"/>
@@ -99,6 +99,12 @@
         </FileInfo>
       </File>
       <File Path="$PPRDIR/../src/boot_ctrl.vhd">
+        <FileInfo SFType="VHDL2008">
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
+      <File Path="$PPRDIR/../src/cache.vhd">
         <FileInfo SFType="VHDL2008">
           <Attr Name="UsedIn" Val="synthesis"/>
           <Attr Name="UsedIn" Val="simulation"/>
@@ -2019,9 +2025,9 @@
           <Option Id="ResourceSharing">2</Option>
           <Option Id="KeepEquivalentRegisters">1</Option>
           <Option Id="NoCombineLuts">1</Option>
+          <Option Id="RepFanoutThreshold">400</Option>
           <Option Id="FsmExtraction">1</Option>
           <Option Id="ShregMinSize">5</Option>
-          <Option Id="RepFanoutThreshold">400</Option>
         </Step>
       </Strategy>
       <GeneratedRun Dir="$PRUNDIR" File="gen_run.xml"/>


### PR DESCRIPTION
- 新增`cache.vhd`。写穿透、写绕过。单个缓存块大小为一个32位字。直接映射。考虑到编译耗时，目前的缓存大小很小，发布时可以调大；
- 为了不破坏原有测例的时序，测例默认工作在无缓存模式。若要在测例中使用缓存，可在测例中使用`CONFIG ENABLE_CACHE`命令；
- 由于缓存行为不同，以前实现的缓存测例无法移植过来。目前没有编写缓存相关的测例；
- Linux和μCore可以照常运行。